### PR TITLE
fix(Weaver): Use utf-8 encoding

### DIFF
--- a/src/impl.w
+++ b/src/impl.w
@@ -1122,7 +1122,7 @@ class Weaver(Emitter):
     def emit(self, web: Web) -> None:
         self.target_path = (self.output / web.web_path.name).with_suffix(f".{self.markup}")
         self.logger.info("Weaving %s using %s markup", self.target_path, self.markup)
-        with self.target_path.open('w') as target_file:
+        with self.target_path.open('w', encoding="utf-8") as target_file:
             for text in self.generate_text(web):
                 self.linesWritten += text.count("\n")
                 target_file.write(text)

--- a/src/pyweb.py
+++ b/src/pyweb.py
@@ -868,7 +868,7 @@ class Weaver(Emitter):
     def emit(self, web: Web) -> None:
         self.target_path = (self.output / web.web_path.name).with_suffix(f".{self.markup}")
         self.logger.info("Weaving %s using %s markup", self.target_path, self.markup)
-        with self.target_path.open('w') as target_file:
+        with self.target_path.open('w', encoding="utf-8") as target_file:
             for text in self.generate_text(web):
                 self.linesWritten += text.count("\n")
                 target_file.write(text)


### PR DESCRIPTION
Problem: UnicodeEncodeError on trying to weave
Solution: Specify `encoding="utf-8"` while emitting 
        the woven target file

Fix https://github.com/slott56/py-web-tool/issues/18