### PR TITLE
fix(rst_tmpl): Add newline after file_xref ...

### DIFF
--- a/src/impl.w
+++ b/src/impl.w
@@ -1411,7 +1411,8 @@ rst_weaver_template = dedent("""
     {% for file in command.files -%}
     :{{file.name}}:
         \N{RIGHTWARDS ARROW} `{{file.name}} ({{file.seq}})`_
-    {%- endfor %}
+
+    {% endfor %}
     {%- endmacro -%}
     
     {%- macro macro_xref(command) -%}

--- a/src/pyweb.py
+++ b/src/pyweb.py
@@ -636,7 +636,8 @@ rst_weaver_template = dedent("""
     {% for file in command.files -%}
     :{{file.name}}:
         \N{RIGHTWARDS ARROW} `{{file.name}} ({{file.seq}})`_
-    {%- endfor %}
+
+    {% endfor %}
     {%- endmacro -%}
     
     {%- macro macro_xref(command) -%}


### PR DESCRIPTION
Problem: No newlines after `@o` output file reference 
Solution: Make it to match the correctly working ones i.e. `@m`macro
        reference. In other words, add a newline before the end tag and
        remove the manual strip-whitespace indicator '-'

Fixes: https://github.com/slott56/py-web-tool/issues/24